### PR TITLE
Remove %HH hex code from possible ids

### DIFF
--- a/api-definition/swagger.yaml
+++ b/api-definition/swagger.yaml
@@ -273,9 +273,9 @@ definitions:
             $ref: "#/definitions/Resource"
           id:
             type: string
-            pattern: "([!*\"'(),+a-zA-Z0-9$-_@.&+\\-]|%[0-9a-fA-F]{2})+"
+            pattern: "([!*\"'(),+a-zA-Z0-9$-_@.&+\\-])+"
             example: "cornelsen-physics-1"
-            description: "The id of the object which should be used instead of a generated id by the service. This includes everything you can put into the url path without the \"/\". The characters are specified in the url standard as \"segment\" https://www.w3.org/Addressing/URL/url-spec.txt page 14/15"
+            description: "The id of the object which should be used instead of a generated id by the service. This includes everything you can put into the url path without the \"/\" and \"%HH\" hexadecimal encoded characters. The characters are specified in the url standard as \"segment\" https://www.w3.org/Addressing/URL/url-spec.txt page 14/15"
   ResourceType:
     type: string
     description: "The type of the resource."

--- a/api-definition/swagger.yaml
+++ b/api-definition/swagger.yaml
@@ -273,7 +273,7 @@ definitions:
             $ref: "#/definitions/Resource"
           id:
             type: string
-            pattern: "([!*\"'(),+a-zA-Z0-9$-_@.&+\\-])+"
+            pattern: "([!*\"'(),+a-zA-Z0-9$_@.&+\\-])+"
             example: "cornelsen-physics-1"
             description: "The id of the object which should be used instead of a generated id by the service. This includes everything you can put into the url path without the \"/\" and \"%HH\" hexadecimal encoded characters. The characters are specified in the url standard as \"segment\" https://www.w3.org/Addressing/URL/url-spec.txt page 14/15"
   ResourceType:


### PR DESCRIPTION
schul-cloud/schul_cloud_resources_server_tests#7

When including %HH hex codes into the id, it is not clear how they will be interpreted in the path and if they are cases sensitive. This reqiuires a lot of testing and opens the spec up for errors in implementations where it is not necessary.