### PR TITLE
use the running test server instance

### DIFF
--- a/api-definition/swagger.yaml
+++ b/api-definition/swagger.yaml
@@ -18,9 +18,6 @@ tags:
   externalDocs:
     description: Find out more
     url: "https://github.com/schul-cloud/resources-api-v1#objects"
-
-# schemes:
-# - http
 paths:
   /resources/ids: # http://jsonapi.org/format/#fetching-resources
     get:
@@ -375,11 +372,8 @@ definitions:
 externalDocs:
   description: Find out more about the API
   url: https://github.com/schul-cloud/resources-api-v1
-# Added by API Auto Mocking Plugin
-host: virtserver.swaggerhub.com
+host: scrst.quelltext.eu
+basePath: /v1
 schemes:
- - https
- - http
-# Added by API Auto Mocking Plugin
-basePath: /niccokunzmann/schul-cloud-content-api/1.0.0
-# basePath: /v1
+- http
+- https


### PR DESCRIPTION
This replaces the mock api with the running instance at http://scrst.quelltext.eu/

https://github.com/schul-cloud/schul_cloud_resources_server_tests/issues/15