### PR TITLE
fix the id pattern of the search reponse

### DIFF
--- a/schemas/search-response/search-response.json
+++ b/schemas/search-response/search-response.json
@@ -150,7 +150,7 @@
       "type": "string",
       "description": "The id of the resource for the search engine. This must be the same as for the resource api.",
       "example": "1",
-      "pattern": "[!*\"'(),+a-zA-Z0-9$-_@.&+\\-]"
+      "pattern": "^[!*\"'(),+a-zA-Z0-9$-_@.&+\\-]*$"
     },
     "JSONAPI": {
       "type": "object",


### PR DESCRIPTION
The id should be a string with onlz the allowed characters. Before, it was not testing this.