### PR TITLE
fix travis error: misspelled file name

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,5 +5,5 @@ set -e
 
 cd "`dirname \"$0\"`"
 
-./deploy_pypi.sh
+./deploy-pypi.sh
 ../generators/node/upload.sh


### PR DESCRIPTION
https://travis-ci.org/schul-cloud/resources-api-v1/builds/274497920#L1855
The file is with minus: https://github.com/schul-cloud/resources-api-v1/blob/master/scripts/deploy-pypi.sh
